### PR TITLE
Use tagged versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,13 @@ RUN apt-get install -y curl git unzip
 
 # define variables
 ARG FLUTTER_SDK=/usr/local/flutter
+ARG FLUTTER_VERSION=3.10.5
 ARG APP=/app/
 
 #clone flutter
 RUN git clone https://github.com/flutter/flutter.git $FLUTTER_SDK
 # change dir to current flutter folder and make a checkout to the specific version
-RUN cd $FLUTTER_SDK && git checkout efbf63d9c66b9f6ec30e9ad4611189aa80003d31
+RUN cd $FLUTTER_SDK && git fetch && git checkout $FLUTTER_VERSION
 
 # setup the flutter path as an enviromental variable
 ENV PATH="$FLUTTER_SDK/bin:$FLUTTER_SDK/bin/cache/dart-sdk/bin:${PATH}"


### PR DESCRIPTION
Since the Flutter team properly tags the releases, we can use them instead of a git hash which is hard to read.